### PR TITLE
Added "Saved Flashcards" Navigation in Navbar

### DIFF
--- a/src/app/api/decks/save/route.ts
+++ b/src/app/api/decks/save/route.ts
@@ -18,6 +18,7 @@ const saveFlashcardsSchema = z.object({
 
 export async function POST(request: NextRequest) {
   try {
+
     // ✅ FIXED: Add await for Clerk v6
     const { userId } = await auth();
     
@@ -26,7 +27,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(error, { status: 401 });
     }
 
+
     const body = await request.json();
+    console.log('📋 Request body:', { 
+      name: body.name, 
+      flashcardCount: body.flashcards?.length || 0 
+    });
+
     const validatedData = saveFlashcardsSchema.parse(body);
 
     // ✅ CORRECT: Use service layer
@@ -35,9 +42,16 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(result, { status: 201 });
     
   } catch (error) {
-    console.error('Error saving flashcards:', error);
+    console.error('❌ Error in POST /api/decks/save:', error);
+    
+    // Enhanced error reporting
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    const errorStack = error instanceof Error ? error.stack : String(error);
+    
+    console.error('❌ Full error details:', { errorMessage, errorStack });
     
     if (error instanceof z.ZodError) {
+      console.log('❌ Validation error:', error.errors);
       const errorResponse: ApiError = {
         error: 'Validation failed',
         details: error.errors.map(err => ({
@@ -48,7 +62,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(errorResponse, { status: 400 });
     }
 
-    const errorResponse: ApiError = { error: 'Failed to save flashcards' };
+    const errorResponse: ApiError = { 
+      error: 'Failed to save flashcards',
+      details: process.env.NODE_ENV === 'development' ? errorMessage : undefined
+    };
     return NextResponse.json(errorResponse, { status: 500 });
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default async function RootLayout({
   // const cookieStore = await cookies();
 
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning={true}>
       <body
         className={cn("min-h-screen font-sans antialiased", inter.className)}
       >

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -24,6 +24,11 @@ const Navbar = () => {
     { href: "/contact", label: "Contact" }
   ];
 
+  // Navigation items only visible when signed in
+  const signedInNavigationLinks = [
+    { href: "/flashcards", label: "Saved Flashcards" }
+  ];
+
   return (
     <motion.nav 
       className="sticky h-16 inset-x-0 top-0 z-50 w-full bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-gray-200/50 dark:border-gray-700/50 transition-all duration-300"
@@ -70,6 +75,23 @@ const Navbar = () => {
                 <Link
                   href={link.href}
                   className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-purple-600 dark:hover:text-purple-400 hover:bg-purple-50 dark:hover:bg-purple-900/20 rounded-lg transition-all duration-200"
+                >
+                  {link.label}
+                </Link>
+              </motion.div>
+            ))}
+            
+            {/* Signed-in only navigation items */}
+            {isSignedIn && signedInNavigationLinks.map((link, index) => (
+              <motion.div
+                key={link.href}
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3, delay: (navigationLinks.length + index) * 0.1 }}
+              >
+                <Link
+                  href={link.href}
+                  className="px-4 py-2 text-sm font-medium text-purple-600 dark:text-purple-400 hover:text-purple-700 dark:hover:text-purple-300 hover:bg-purple-50 dark:hover:bg-purple-900/20 rounded-lg transition-all duration-200 border border-purple-200 dark:border-purple-700"
                 >
                   {link.label}
                 </Link>
@@ -183,6 +205,24 @@ const Navbar = () => {
                     <Link
                       href={link.href}
                       className="block px-4 py-3 text-gray-700 dark:text-gray-300 hover:text-purple-600 dark:hover:text-purple-400 hover:bg-purple-50 dark:hover:bg-purple-900/20 rounded-lg transition-all duration-200 font-medium"
+                      onClick={() => setIsMobileMenuOpen(false)}
+                    >
+                      {link.label}
+                    </Link>
+                  </motion.div>
+                ))}
+
+                {/* Mobile Signed-in only navigation items */}
+                {isSignedIn && signedInNavigationLinks.map((link, index) => (
+                  <motion.div
+                    key={link.href}
+                    initial={{ opacity: 0, x: -20 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    transition={{ duration: 0.3, delay: (navigationLinks.length + index) * 0.1 }}
+                  >
+                    <Link
+                      href={link.href}
+                      className="block px-4 py-3 text-purple-600 dark:text-purple-400 hover:text-purple-700 dark:hover:text-purple-300 hover:bg-purple-50 dark:hover:bg-purple-900/20 rounded-lg transition-all duration-200 font-medium border border-purple-200 dark:border-purple-700"
                       onClick={() => setIsMobileMenuOpen(false)}
                     >
                       {link.label}

--- a/src/components/flashcards/FlashcardSaveDialog.tsx
+++ b/src/components/flashcards/FlashcardSaveDialog.tsx
@@ -57,8 +57,8 @@ export default function FlashcardSaveDialog({
       const requestData = {
         name: deckName.trim(),
         flashcards: flashcards.map(card => ({
-          question: card.question,
-          answer: card.answer
+          question: card.question.trim(),
+          answer: card.answer.trim()
         }))
       };
 
@@ -82,12 +82,16 @@ export default function FlashcardSaveDialog({
         const errorMessage = errorData.error || `HTTP ${response.status}: Failed to save flashcards`;
         
         // Show specific error details if available
-        if (errorData.details && Array.isArray(errorData.details)) {
-          const validationErrors = errorData.details.map((detail: any) => 
-            `${detail.field}: ${detail.message}`
-          ).join(', ');
-          throw new Error(`${errorMessage} (${validationErrors})`);
-        }
+        if (errorData.details) {
+          if (Array.isArray(errorData.details)) {
+            const validationErrors = errorData.details
+              .map((detail: any) => `${detail.field}: ${detail.message}`)
+              .join(', ');
+            throw new Error(`${errorMessage} (${validationErrors})`);
+          } else if (typeof errorData.details === 'string') {
+            throw new Error(`${errorMessage} (${errorData.details})`);
+          }
+          }
         
         throw new Error(errorMessage);
       }


### PR DESCRIPTION
### **Description**
Added "Saved Flashcards" Navigation in Navbar (which is visible to signed users only)

### 
**Issue Number**
Closes: #93 

### **Changes Made**

- Uses Clerk's useUser() hook to detect if someone is signed in
- isSignedIn is a boolean that's true when user is authenticated
- Created a separate array for auth-only navigation items
- Links to /flashcards page (which already existed)

Type Of Change
 Navigation fix to make the accessibility easier of saved flashcards 

Screenshots or Videos
Before (without sigin)
![WhatsApp Image 2025-08-29 at 22 55 25_c171a4ce](https://github.com/user-attachments/assets/169001d6-0f2f-4d50-877a-9f4956b183e1)

After (with signin)
![WhatsApp Image 2025-08-29 at 22 56 19_65dee24a](https://github.com/user-attachments/assets/9458a24f-5f03-4eea-95cf-b6cee836e416)


How Has This Been Tested?
locally on my machine


**Checklist**

- [ ]  My code follows the style guidelines of this project
- [ ]  I have performed a self-review of my code
- [ ]  I have commented on my code, particularly in hard-to-understand areas
- [ ]  I have made corresponding changes to the documentation
- [ ]  My changes generate no new warnings
- [ ]  I have added tests that prove my fix is effective or that my feature works
- [ ]  New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a “Saved Flashcards” navigation link for signed-in users (desktop and mobile).
  - Success toast now names the saved deck.

- Bug Fixes
  - Prevents saving when no flashcards are present.
  - Clearer, more actionable error messages for validation, unauthorized, and network failures.
  - Loading state reliably resets after save attempts.
  - Reduced hydration-related flicker.

- Chores
  - Improved error reporting and environment-appropriate error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->